### PR TITLE
1561956 generic worker 15 add key from vault

### DIFF
--- a/modules/generic_worker/manifests/multiuser.pp
+++ b/modules/generic_worker/manifests/multiuser.pp
@@ -19,6 +19,7 @@ class generic_worker::multiuser (
     Pattern[/^v\d+\.\d+\.\d+$/] $livelog_version,
     String $livelog_sha256,
     String $taskcluster_host = 'taskcluster',
+    Optional[String] $ed25519_signing_key_content = undef,
 ) {
 
     include httpd
@@ -38,6 +39,16 @@ class generic_worker::multiuser (
     $downloads_dir       = "${gw_dir}/downloads"
     $ed25519_signing_key = "${gw_dir}/generic-worker.ed25519.signing.key"
 
+    if $ed25519_signing_key_content {
+        file {
+            $ed25519_signing_key:
+                ensure  => present,
+                content => $ed25519_signing_key_content,
+                mode    => '0600',
+                owner   => $::root_user,
+                group   => $::root_group,
+        }
+    }
     exec {
         'create ed25519 signing key':
             path    => ['/bin', '/sbin', '/usr/local/bin', '/usr/bin'],

--- a/modules/roles_profiles/manifests/profiles/gecko_3_t_osx_1014_generic_worker.pp
+++ b/modules/roles_profiles/manifests/profiles/gecko_3_t_osx_1014_generic_worker.pp
@@ -38,6 +38,7 @@ class roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker {
             $quarantine_client_id     = lookup('generic_worker.gecko_3_t_osx_1014.quarantine_client_id')
             $quarantine_access_token  = lookup('generic_worker.gecko_3_t_osx_1014.quarantine_access_token')
             $bugzilla_api_key         = lookup('generic_worker.gecko_3_t_osx_1014.bugzilla_api_key')
+            $ed25519_signing_key      = lookup('generic_worker.gecko_3_t_osx_1014.ed25519_signing_key')
 
             class { 'generic_worker::multiuser':
                 taskcluster_client_id     => $taskcluster_client_id,
@@ -55,6 +56,7 @@ class roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker {
                 livelog_sha256            => 'caabc35ec26498e755863d08c4c8b79e8b041a1d11b1fc8be0909718fc81113d',
                 user                      => 'root',
                 gw_dir                    => '/var/local/generic-worker',
+                ed25519_signing_key_content => $ed25519_signing_key,
             }
 
             include dirs::tools

--- a/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
+++ b/modules/roles_profiles/manifests/roles/gecko_3_t_osx_1014.pp
@@ -21,6 +21,7 @@ class roles_profiles::roles::gecko_3_t_osx_1014 {
     include ::roles_profiles::profiles::cltbld_user
     include ::roles_profiles::profiles::homebrew
     include ::roles_profiles::profiles::relops_users
+    include ::roles_profiles::profiles::remove_bootstrap_user
     include ::roles_profiles::profiles::gecko_3_t_osx_1014_generic_worker
     include ::fw::roles::osx_taskcluster_worker
 }


### PR DESCRIPTION
@dragoscrisan I added the cot key content onto install1/install3 vault for when the pgo workers are reimaged. This will place that as the contents of the key file (before generating one?!).